### PR TITLE
Fixing an issue with og:image for posts

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,8 +15,6 @@ layout: compress
 
     <meta name=description content="{{ site.bio }}">
     <meta name=author content="{{ site.name }}">
-    <meta property="og:image" content="{{ site.url }}/{{ site.picture }}">
-    <meta property="og:type" content="profile">
 
     {% seo %}
     


### PR DESCRIPTION
Fixing an issue where all links will be shown with the site's image, instead of the image specified in the `image` field in the specific post's front matter. More info: https://github.com/sergiokopplin/indigo/issues/350